### PR TITLE
TCP Server: Expose a config directive to select the interface to bind.

### DIFF
--- a/README.org
+++ b/README.org
@@ -56,6 +56,11 @@
   : {
   :   "tcp": {
   :     "threads": 30
+***** By default, The recognizer TCP server binds to =0.0.0.0=
+  Make the TCP server listen only on local interface.
+  : {
+  :   "tcp": {
+  :   "address": "127.0.0.1"
 ***** By default, Recognizer binds the AMQP queue =recognizer= to the topic exchange =graphite= with the routing key =#=
   Use a custom AMQP exchange
   : {

--- a/lib/recognizer/inputs/tcp.rb
+++ b/lib/recognizer/inputs/tcp.rb
@@ -22,7 +22,8 @@ module Recognizer
 
       def setup_server
         port       = @options[:tcp][:port] || 2003
-        tcp_server = TCPServer.new("0.0.0.0", port)
+        address    = @options[:tcp][:address] || '0.0.0.0'
+        tcp_server = TCPServer.new(address, port)
         Thread.new do
           @logger.info("TCP -- Awaiting metrics with impatience ...")
           loop do


### PR DESCRIPTION
Some setups should be fine with listening on a local port and a local aggregator pushing logs to the deamon, its better not start an insecure tcp server on a public port be default.
